### PR TITLE
Fix wrong aspect ratio in product image caused by product labels module in Kadence theme

### DIFF
--- a/inc/modules/product-labels/class-product-labels.php
+++ b/inc/modules/product-labels/class-product-labels.php
@@ -467,7 +467,6 @@ class Merchant_Product_Labels extends Merchant_Add_Module {
 		// Kadence
 		if ( 'Kadence' === $theme_name ) {
 			$css .= '
-			    .merchant-product-labels-image-wrap img,
 				.merchant_product-labels-grid_item_html a,
 				.merchant_product-labels-grid_item_html .wc-block-grid__product-image,
 				.merchant_product-labels-grid_item_html .wc-block-grid__product-image img {


### PR DESCRIPTION
Fix wrong aspect ratio in product image caused by product labels module in Kadence theme.

Case: https://secure.helpscout.net/conversation/2987967399/34122?viewId=1287525