### PR TITLE
Fix product variations not considered as pre-orders

### DIFF
--- a/assets/js/src/modules/pre-orders/pre-orders.js
+++ b/assets/js/src/modules/pre-orders/pre-orders.js
@@ -36,11 +36,14 @@ merchant.modules = merchant.modules || {};
 				}
 				
 				$product.removeClass('merchant-pre-ordered-product');
-				
-				if( variation.is_pre_order == true ) {
+				if( variation.is_pre_order === true ) {
 					if ( variation.is_pre_order_date ) {
 						$product.addClass('merchant-pre-ordered-product');
-						$product.find('.woocommerce-variation-add-to-cart').before('<div class="merchant-pre-orders-date">'+ variation.is_pre_order_date +'</div>')
+						if(variation.pre_order_placement === 'before'){
+							$product.find('.variations_form.cart').before('<div class="merchant-pre-orders-date">'+ variation.is_pre_order_date +'</div>');
+						} else if(variation.pre_order_placement === 'after') {
+							$product.find('.variations_form.cart').after('<div class="merchant-pre-orders-date">'+ variation.is_pre_order_date +'</div>');
+						}
 					}
 					$button.html(window.merchant.setting.pre_orders_add_button_title);
 				} else {

--- a/inc/classes/class-merchant-metabox.php
+++ b/inc/classes/class-merchant-metabox.php
@@ -332,7 +332,7 @@ if ( ! class_exists( 'Merchant_Metabox' ) ) {
 
 						echo '<div class="merchant-metabox-field-content">';
 
-						$meta    = get_post_meta( $post->ID, $field_id );
+						$meta    = get_post_meta( $post->ID, $field_id, false );
 						$default = ( isset( $field['default'] ) ) ? $field['default'] : null;
 						$value   = ( isset( $meta[0] ) ) ? $meta[0] : $default;
 

--- a/inc/modules/pre-orders/class-pre-orders-main-functionality.php
+++ b/inc/modules/pre-orders/class-pre-orders-main-functionality.php
@@ -61,7 +61,7 @@ class Merchant_Pre_Orders_Main_Functionality {
 
 		add_filter( 'woocommerce_product_add_to_cart_text', array( $this, 'change_button_text' ), 10, 2 );
 		add_filter( 'woocommerce_product_single_add_to_cart_text', array( $this, 'change_button_text' ), 10, 2 );
-		add_filter( 'woocommerce_available_variation', array( $this, 'change_button_text_for_variable_products' ), 10, 3 );
+		add_filter( 'woocommerce_available_variation', array( $this, 'attach_pre_order_data_to_variations' ), 10, 3 );
 		add_action( 'woocommerce_before_add_to_cart_form', array( $this, 'additional_information_before_cart_form' ) );
 		add_action( 'woocommerce_after_add_to_cart_form', array( $this, 'additional_information_after_cart_form' ) );
 
@@ -937,15 +937,18 @@ class Merchant_Pre_Orders_Main_Functionality {
 	/**
 	 * Change pre-order button text for variable products.
 	 *
-	 * @param array  $data
-	 * @param object $product
-	 * @param object $variation
+	 * @param array                $data      variation data.
+	 * @param WC_Product           $product   The product object.
+	 * @param WC_Product_Variation $variation The variation object.
 	 *
 	 * @return array
 	 */
-	public function change_button_text_for_variable_products( $data, $product, $variation ) {
-		if ( $this->is_pre_order( $variation->get_id() ) ) {
-			$pre_order_rule = self::available_product_rule( $variation->get_id() );
+	public function attach_pre_order_data_to_variations( $data, $product, $variation ) {
+		$pre_order_rule = self::available_product_rule( $variation->get_id() );
+		if ( empty( $pre_order_rule ) ) {
+			$pre_order_rule = self::available_product_rule( $product->get_id() );
+		}
+		if ( ! empty( $pre_order_rule ) ) {
 			$data['is_pre_order'] = true;
 
 			$additional_text = $pre_order_rule['additional_text'] ? Merchant_Translator::translate( $pre_order_rule['additional_text'] )

--- a/inc/modules/pre-orders/class-pre-orders-main-functionality.php
+++ b/inc/modules/pre-orders/class-pre-orders-main-functionality.php
@@ -949,7 +949,8 @@ class Merchant_Pre_Orders_Main_Functionality {
 			$pre_order_rule = self::available_product_rule( $product->get_id() );
 		}
 		if ( ! empty( $pre_order_rule ) ) {
-			$data['is_pre_order'] = true;
+			$data['is_pre_order']        = true;
+			$data['pre_order_placement'] = isset( $pre_order_rule['placement'] ) ? $pre_order_rule['placement'] : 'before';
 
 			$additional_text = $pre_order_rule['additional_text'] ? Merchant_Translator::translate( $pre_order_rule['additional_text'] )
 				: esc_html__( 'Ships on {date}.', 'merchant' );


### PR DESCRIPTION
In pre-orders module, when selecting a variable product as a trigger, the variations for that product aren't considered as a pre-order product.
That results in not showing the "ships on" sentence that should appear on product single page

See #491 