### PR TITLE
Update "merchant_admin_upgrade_link" function to allow third-party integrations

### DIFF
--- a/admin/classes/class-merchant-admin-menu.php
+++ b/admin/classes/class-merchant-admin-menu.php
@@ -401,11 +401,20 @@ if ( ! class_exists( 'Merchant_Admin_Menu' ) ) {
 
 			// Upgrade to Pro (if not already defined)
 			if ( ! defined( 'MERCHANT_PRO_VERSION' ) ) {
+				$url = merchant_admin_upgrade_link(
+					'https://athemes.com/merchant-upgrade',
+					array(
+						'utm_source'   => 'theme_submenu_page',
+						'utm_medium'   => 'button',
+						'utm_campaign' => 'Merchant',
+					),
+					'adminbar-submenu-page-upgrade-link'
+				);
 				$wp_admin_bar->add_node( array(
 					'id'     => 'merchant-upgrade',
 					'parent' => 'merchant-dashboard',
 					'title'  => esc_html__( 'Upgrade to Pro', 'merchant' ),
-					'href'   => 'https://athemes.com/merchant-upgrade?utm_source=theme_submenu_page&utm_medium=button&utm_campaign=Merchant',
+					'href'   => esc_url( $url ),
 					'meta'   => array(
 						'title'  => esc_html__( 'Upgrade to Pro', 'merchant' ),
 						'target' => '_blank', // Open link in a new tab

--- a/admin/classes/class-merchant-admin-menu.php
+++ b/admin/classes/class-merchant-admin-menu.php
@@ -300,14 +300,23 @@ if ( ! class_exists( 'Merchant_Admin_Menu' ) ) {
 
 			// Add 'Upgrade' link.
 			if ( ! defined( 'MERCHANT_PRO_VERSION' ) ) {
+				$url = merchant_admin_upgrade_link(
+					'https://athemes.com/merchant-upgrade',
+					array(
+						'utm_source'   => 'theme_submenu_page',
+						'utm_medium'   => 'button',
+						'utm_campaign' => 'Merchant',
+					),
+					'theme-submenu-page-upgrade-link'
+				);
 				add_submenu_page(
 					$this->plugin_slug,
-					esc_html__('Upgrade to Pro', 'merchant'),
-					esc_html__('Upgrade to Pro', 'merchant'),
+					esc_html__( 'Upgrade to Pro', 'merchant' ),
+					esc_html__( 'Upgrade to Pro', 'merchant' ),
 					$this->capability,
-					'https://athemes.com/merchant-upgrade?utm_source=theme_submenu_page&utm_medium=button&utm_campaign=Merchant',
+					esc_url( $url ),
 					'',
-            7
+					7
 				);
 			}
 		}

--- a/admin/notices/class-merchant-notice-upsell.php
+++ b/admin/notices/class-merchant-notice-upsell.php
@@ -44,6 +44,17 @@ class Merchant_Notice_Upsell extends Merchant_Notice {
 			return;
 		}
 
+	    $url = merchant_admin_upgrade_link(
+		    'https://athemes.com/merchant-upgrade',
+		    array(
+			    'utm_source'   => 'plugin_notice',
+			    'utm_content'  => 'upgrade_notice',
+			    'utm_medium'   => 'button',
+			    'utm_campaign' => 'Merchant',
+		    ),
+            'plugin-admin-notice'
+	    );
+
 		?>
         <div class="merchant-notice merchant-notice-with-thumbnail notice" style="position:relative;">
 			<h3><?php echo esc_html__( 'Supercharge Your Store with Merchant Pro! 🚀', 'merchant' ); ?></h3>
@@ -54,7 +65,7 @@ class Merchant_Notice_Upsell extends Merchant_Notice {
 				?>
 			</p>
 
-			<a href="https://athemes.com/merchant-upgrade?utm_source=plugin_notice&utm_content=upgrade_notice&utm_medium=button&utm_campaign=Merchant" class="merchant-btn merchant-btn-secondary" target="_blank"><?php esc_html_e( 'Upgrade To Merchant Pro', 'merchant' ); ?></a>
+			<a href="<?php echo esc_url( $url ) ?>" class="merchant-btn merchant-btn-secondary" target="_blank"><?php esc_html_e( 'Upgrade To Merchant Pro', 'merchant' ); ?></a>
 			
 			<a class="notice-dismiss" href="?<?php echo esc_attr( $this->id ); ?>_dismiss=1" style="text-decoration:none;"></a>
 		</div>

--- a/admin/pages/page-module.php
+++ b/admin/pages/page-module.php
@@ -66,10 +66,21 @@ Merchant_Admin_Preview::set_preview( $merchant_module );
                                 <div class="merchant-module-action<?php echo esc_attr( $merchant_module_enabled ); ?>">
 
 
-									<?php if ( $merchant_module_is_upsell ) : ?>
+									<?php if ( $merchant_module_is_upsell ) :
+										$url = merchant_admin_upgrade_link(
+											'https://athemes.com/merchant-upgrade',
+											array(
+												'utm_source'   => 'module_inner_settings',
+												'utm_content'  => $merchant_module,
+												'utm_medium'   => 'merchant_dashboard',
+												'utm_campaign' => 'Merchant',
+											),
+											'module-inner-settings-upgrade-link'
+										);
+										?>
                                         <div class="merchant-module-buy">
 
-                                            <a href="https://athemes.com/merchant-upgrade?utm_source=module_inner_settings&utm_content=<?php echo esc_attr( $merchant_module ); ?>&utm_medium=merchant_dashboard&utm_campaign=Merchant" target="_blank"
+                                            <a href="<?php echo esc_url( $url ); ?>" target="_blank"
                                                 class="merchant-module-page-button ">
 												<?php esc_html_e( 'Buy Pro', 'merchant' ); ?>
                                             </a>

--- a/inc/class-merchant-loader.php
+++ b/inc/class-merchant-loader.php
@@ -217,18 +217,18 @@ if ( ! class_exists( 'Merchant_Loader' ) ) {
 		 */
 		public function settings_link( $links ) {
 			if ( ! merchant_pro_is_active() || ! merchant_pro_license_exists() ) {
+				$url = merchant_admin_upgrade_link(
+					'https://athemes.com/merchant/#pricing',
+					array(),
+					'plugins-page-upgrade-link'
+				);
 				$links['merchant-pro'] = sprintf(
 					'<a href="%1$s" aria-label="%2$s" target="_blank" rel="noopener noreferrer"
 				style="color: #00a32a; font-weight: 700;"
 				onmouseover="this.style.color=\'#008a20\';"
 				onmouseout="this.style.color=\'#00a32a\';"
 				>%3$s</a>',
-					esc_url(
-						merchant_admin_upgrade_link(
-							'all-plugins',
-							'Get Merchant Pro'
-						)
-					),
+					esc_url( $url ),
 					esc_attr__( 'Upgrade to Merchant Pro', 'merchant' ),
 					esc_html__( 'Get Merchant Pro', 'merchant' )
 				);

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -266,23 +266,36 @@ if ( ! function_exists( 'merchant_admin_upgrade_link' ) ) {
 	/**
 	 * Get the Merchant Pro upgrade link.
 	 *
-	 * @param string $medium  The medium type (link, button, etc.).
-	 * @param string $content The content to display.
+	 * @param string $url  The base URL for the upgrade link.
+	 * @param array  $args The arguments for the upgrade link. (Key-value pairs)
+	 * @param string $type The type of upgrade link.
 	 *
 	 * @return string The upgrade link.
 	 */
-	function merchant_admin_upgrade_link( $medium = 'link', $content = '' ) {
-		$url = 'https://athemes.com/merchant/#pricing';
+	function merchant_admin_upgrade_link( $url, $args = array(), $type = 'plugins-page-upgrade-link' ) {
+		/**
+		 * Filter the upgrade link URL args.
+		 *
+		 * @param array  $args The arguments for the upgrade link.
+		 * @param string $type The type of upgrade link.
+		 *
+		 * @since 2.1.5
+		 */
+		$args = apply_filters( 'merchant_admin_upgrade_link_args', $args, $type );
+		if ( ! empty( $args ) ) {
+			$url = add_query_arg( $args, $url );
+		}
 
 		/**
 		 * Modify upgrade link.
 		 *
 		 * @param string $upgrade Upgrade links.
+		 * @param string $type    The type of upgrade link.
 		 *
-		 * @since 2.1.2
+		 * @since 2.1.5
 		 *
 		 */
-		return apply_filters( 'merchant_upgrade_link', $url );
+		return apply_filters( 'merchant_upgrade_link', $url, $type );
 	}
 }
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -273,15 +273,6 @@ if ( ! function_exists( 'merchant_admin_upgrade_link' ) ) {
 	 * @return string The upgrade link.
 	 */
 	function merchant_admin_upgrade_link( $url, $args = array(), $type = 'plugins-page-upgrade-link' ) {
-		/**
-		 * Filter the upgrade link URL args.
-		 *
-		 * @param array  $args The arguments for the upgrade link.
-		 * @param string $type The type of upgrade link.
-		 *
-		 * @since 2.1.5
-		 */
-		$args = apply_filters( 'merchant_admin_upgrade_link_args', $args, $type );
 		if ( ! empty( $args ) ) {
 			$url = add_query_arg( $args, $url );
 		}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -317,7 +317,7 @@ if ( ! function_exists( 'merchant_pro_license_exists' ) ) {
 	 * @return bool
 	 */
 	function merchant_pro_license_exists() {
-		return ! empty( get_option( 'merchant_license_key' ) );
+		return ! empty( get_option( 'merchant_pro_license_key' ) );
 	}
 }
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -289,8 +289,8 @@ if ( ! function_exists( 'merchant_admin_upgrade_link' ) ) {
 		/**
 		 * Modify upgrade link.
 		 *
-		 * @param string $upgrade Upgrade links.
-		 * @param string $type    The type of upgrade link.
+		 * @param string $url  The upgrade link URL.
+		 * @param string $type The type of upgrade link.
 		 *
 		 * @since 2.1.5
 		 *


### PR DESCRIPTION
The `merchant_admin_upgrade_link()` function updated to include the following parameters

- URL: String, The base URL for the upgrade link.
- Args: Array, The arguments for the upgrade link. (Key-value pairs) (optional)
- Type: String: The type of upgrade link. (optional)

The Args parameter is filterable using the `merchant_admin_upgrade_link_args` which is using the type parameter.

The URL parameter is filterable using the `merchant_upgrade_link` which is using the type parameter.

See #493 