### PR TITLE
Add multi-currency support for storewide sale cart item price

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   # Run php tests.
   php-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     strategy:
       matrix:

--- a/.github/workflows/demos-network-deploy.yml
+++ b/.github/workflows/demos-network-deploy.yml
@@ -10,7 +10,7 @@ on:
       
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: 🚚 Get latest code
         uses: actions/checkout@v3
@@ -63,7 +63,7 @@ jobs:
   
       - name: 📂 Deploy files to the Demos Network
         uses: easingthemes/ssh-deploy@main
-          
+
         env:
           SSH_PRIVATE_KEY: ${{secrets.SERVER_SSH_KEY}}
           ARGS: "-rlgoDzvc -i --delete"

--- a/.github/workflows/production-plugin.yml
+++ b/.github/workflows/production-plugin.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-plugin-zip-asset:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code

--- a/inc/compatibility/class-merchant-woo-multi-currency.php
+++ b/inc/compatibility/class-merchant-woo-multi-currency.php
@@ -25,6 +25,10 @@ if ( ! class_exists( 'Merchant_Woo_Multi_Currency' ) ) {
 			add_filter( 'merchant_fbt_cart_item_price', array( $this, 'multi_currency_free_support' ) );
 			add_filter( 'merchant_fbt_cart_item_price', array( $this, 'multi_currency_pro_support' ) );
 
+			// Add multi-currency support for Storewide sale cart item price
+			add_filter( 'merchant_storewide_sale_cart_item_price', array( $this, 'multi_currency_free_support' ) );
+			add_filter( 'merchant_storewide_sale_cart_item_price', array( $this, 'multi_currency_pro_support' ) );
+
 			add_filter( 'merchant_free_gifts_min_amount', array( $this, 'multi_currency_support_free_gifts' )  );
 			add_filter( 'merchant_free_gifts_min_amount', array( $this, 'multi_currency_pro_support_free_gifts' )  );
 		}


### PR DESCRIPTION
Using the cart item price filter from storewide sale module `merchant_storewide_sale_cart_item_price` we are able to filter the item price and make it compatible with Curcy plugin.

Steps to test:
1. Install Curcy Free [plugin](https://wordpress.org/plugins/woo-multi-currency/)
2. Activate Storewide sale module
3. Add an item to the cart that contains a sale from that module
4. Convert the currencies to check for any incorrect prices according to the exchange rate you set in the curcy plugin dashboard.
5. Repeat the process with the [curcy pro version](https://drive.google.com/drive/folders/12WvZJgWZ872KojtTg9Hk1RJAx25c22lS?usp=drive_link).

See #503 