### PR TITLE
Allow the upgrade URL to be visible only if Merchant pro isn't active

### DIFF
--- a/inc/class-merchant-loader.php
+++ b/inc/class-merchant-loader.php
@@ -216,7 +216,7 @@ if ( ! class_exists( 'Merchant_Loader' ) ) {
 		 * @return array $links
 		 */
 		public function settings_link( $links ) {
-			if ( ! merchant_pro_is_active() || ! merchant_pro_license_exists() ) {
+			if ( ! merchant_pro_is_active() ) {
 				$url = merchant_admin_upgrade_link(
 					'https://athemes.com/merchant/#pricing',
 					array(),


### PR DESCRIPTION
Change the conditions of the upgrade URL to be visible only if Merchant pro isn't active